### PR TITLE
High contrast assets

### DIFF
--- a/kwc-badge.html
+++ b/kwc-badge.html
@@ -40,12 +40,10 @@ Custom property | Description | Default
                 width: 100px;
                 -webkit-filter: grayscale(100%);
                 filter: grayscale(100%);
-                opacity: 0.4;
             }
             :host([unlocked]) iron-image {
                 -webkit-filter: grayscale(0%);
                 filter: grayscale(0%);
-                opacity: 1;
             }
             :host .triangle {
                 border-left: 16px solid transparent;


### PR DESCRIPTION
Remove opacity on disabled medals/badges to improve display on low contrast screens (Computer Kits, for example)

https://trello.com/c/CVSDxqEf