### PR TITLE
Degrade tooltip on mobile

### DIFF
--- a/kwc-badge.html
+++ b/kwc-badge.html
@@ -67,6 +67,17 @@ Custom property | Description | Default
             :host *[hidden] {
                 display: none;
             }
+
+            /*
+            XXX: Hide fullscreen button on mobile screens while the
+            functionality until a full responsive solution is in place.
+            `768px` is the current media query value for `kwc-masthead`.
+            */
+            @media (max-width: 768px) {
+                paper-tooltip {
+                    display: none;
+                }
+            }
         </style>
         <iron-image id="badge"
                     alt="[[title]]"


### PR DESCRIPTION
This PR is a temporary solution for the issue described in [this Trello card](https://trello.com/c/z1XPV6Oe/1560-the-medal-overlays-on-profile-get-mis-aligned-on-safari-mobile-web).