### PR TITLE
Import & use 'kwc-paper-tooltip' instead of 'paper-tooltip'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.9.0",
     "iron-image": "^2.1.2",
-    "kwc-paper-tooltip": "KanoComponents/kwc-paper-tooltip",
+    "kwc-paper-tooltip": "git@github.com:KanoComponents/kwc-paper-tooltip",
     "web-components": "git@github.com:KanoComputing/web-components.git#master",
     "iron-flex-layout": "^2.0.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.9.0",
     "iron-image": "^2.1.2",
-    "kwc-paper-tooltip": "git@github.com:KanoComponents/kwc-paper-tooltip#b8ba64d13701952a8d8d7a82e43327a3afd4f5c5",
+    "kwc-paper-tooltip": "KanoComponents/kwc-paper-tooltip#^2.x",
     "web-components": "git@github.com:KanoComputing/web-components.git#master",
     "iron-flex-layout": "^2.0.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.9.0",
     "iron-image": "^2.1.2",
-    "kwc-paper-tooltip": "git@github.com:KanoComponents/kwc-paper-tooltip",
+    "kwc-paper-tooltip": "git@github.com:KanoComponents/kwc-paper-tooltip#b8ba64d13701952a8d8d7a82e43327a3afd4f5c5",
     "web-components": "git@github.com:KanoComputing/web-components.git#master",
     "iron-flex-layout": "^2.0.0"
   },

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.9.0",
     "iron-image": "^2.1.2",
-    "paper-tooltip": "^2.0.1",
+    "kwc-paper-tooltip": "KanoComponents/kwc-paper-tooltip",
     "web-components": "git@github.com:KanoComputing/web-components.git#master",
     "iron-flex-layout": "^2.0.0"
   },

--- a/kwc-badge.html
+++ b/kwc-badge.html
@@ -1,7 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../iron-image/iron-image.html">
-<link rel="import" href="../paper-tooltip/paper-tooltip.html">
+<link rel="import" href="../kwc-paper-tooltip/kwc-paper-tooltip.html">
 <link rel="import" href="../web-components/kano-style/kano-style.html">
 
 <!--
@@ -56,11 +56,11 @@ Custom property | Description | Default
                 top: -8px;
                 width: 0;
             }
-            :host paper-tooltip h3 {
+            :host kwc-paper-tooltip h3 {
                 font-size: 18px;
                 margin: 0px 0px 10px 0px;
             }
-            :host paper-tooltip p {
+            :host kwc-paper-tooltip p {
                 font-size: 16px;
                 margin: 0px 0px 5px 0px;
             }
@@ -74,7 +74,7 @@ Custom property | Description | Default
             `768px` is the current media query value for `kwc-masthead`.
             */
             @media (max-width: 768px) {
-                paper-tooltip {
+                kwc-paper-tooltip {
                     display: none;
                 }
             }
@@ -85,7 +85,7 @@ Custom property | Description | Default
                     src="[[imageUrl]]">
                     </iron-image>
         <template is="dom-if" if="[[tooltip]]">
-            <paper-tooltip for="badge"
+            <kwc-paper-tooltip for="badge"
                            animation-delay="0"
                            margin-top="20"
                            position="bottom"
@@ -94,7 +94,7 @@ Custom property | Description | Default
                 <h3>[[title]]</h3>
                 <p hidden$="[[_displayDescription]]">[[criteria]]</p>
                 <p hidden$="[[!_displayDescription]]">[[description]]</p>
-            </paper-tooltip>
+            </kwc-paper-tooltip>
         </template>
     </template>
 

--- a/test/kwc-badge_test.html
+++ b/test/kwc-badge_test.html
@@ -56,7 +56,7 @@
 
                 test('should show the tooltip by default', function(done) {
                     flush(function() {
-                        var children =  Polymer.dom(basic.root).querySelectorAll('paper-tooltip');
+                        var children =  Polymer.dom(basic.root).querySelectorAll('kwc-paper-tooltip');
                         assert.lengthOf(children, 1);
                         done();
                     });
@@ -65,7 +65,7 @@
                 test('should not show the tooltip by when suppressed', function(done) {
                     basic.tooltip = false;
                     flush(function() {
-                        var children =  Polymer.dom(basic.root).querySelectorAll('paper-tooltip');
+                        var children =  Polymer.dom(basic.root).querySelectorAll('kwc-paper-tooltip');
                         assert.lengthOf(children, 0);
                         done();
                     });


### PR DESCRIPTION
I created this PR as result of the other PR:
https://github.com/KanoComponents/kwc-paper-tooltip/pull/1

I imported and used `kwc-paper-tooltip` instead of the base `paper-tooltip` component provided by Polymer.
I also added it to dependencies.